### PR TITLE
Readding line logging into RETs server

### DIFF
--- a/export.php
+++ b/export.php
@@ -13,6 +13,8 @@ $config = new \PHRETS\Configuration;
 $config->setLoginUrl($endpoint->url)->setUsername($endpoint->user)->setPassword($endpoint->pass)->setRetsVersion($endpoint->version);
 $rets = new \PHRETS\Session($config);
 
+$connect = $rets->Login();
+
 if (!$connect) {
 	die($rets->Error());
 }


### PR DESCRIPTION
Why
* PHRETS requires 'login' to be called in order to pull RETs metadata

Changes
* Added line 16; $connect = $rets->Login();